### PR TITLE
Improve tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To compile the project, simply run `just build`, followed by the targets you wis
 - `linux`
 - `windows`
 - `mac`
+- `rpi` - Raspberry Pi model 2/3/4
+- `rpi-legacy` - Raspberry Pi model 0/1
 
 # Examples
 Soon....

--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 KIROS is a collection of cross-platform modules designed to empower developers to build modular, cross-platform robotics systems for use in disaster situations. KIROS is based on my experiences from developing & deploying [RoboHUD](https://github.com/CCGSRobotics/RoboHUD) at the RoboCup RMRC competition in 2019.  
 
 # Installation
-As the project in its current form is quite barebones (and under heavy active development), it is fairly difficult to utilise it effectively in production. If you would like to check it out, simply clone the repository and have a look at the source code.
+As the project in its current form is quite barebones (and under heavy active development), it is fairly difficult to utilise it effectively in production. If you would like to check it out, please follow these steps:
+- `git clone https://github.com/kiros-rs/kiros`
+- `cd kiros`
+- Install [just](https://github.com/casey/just)
+- `just install-toolchain`
+- `just build`
 
 # Building the project
-This section is a placeholder for now, just use `cargo build` to generate an executable. A more advanced build system will soon replace this, using the `just` framework.
+To compile the project, simply run `just build`, followed by the targets you wish to build for (default is local machine). For example, `just build linux windows` builds for linux & windows, while `just build` will run for the local machine. When compiling for a target, the script also installs the required Rust toolchains for you! Here are all the currently supported targets:
+- `all`
+- `linux`
+- `windows`
+- `mac`
 
 # Examples
 Soon....

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -3,6 +3,7 @@ name = "connection"
 version = "0.1.0"
 authors = ["Angus Finch <developer.finchie@gmail.com>"]
 edition = "2018"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,191 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url of the advisory database to use
+db-url = "https://github.com/rustsec/advisory-db"
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold = 
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explictly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    # "Apache-2.0",
+    # "Apache-2.0 WITH LLVM-exception",
+]
+# List of explictly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# THe optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "warn"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate 
+# detection. Unlike skip, it also includes the entire tree of transitive 
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ lint:
   cargo fmt
   cargo fix --allow-dirty --allow-staged
 
+# Build the selected targets
 build *targets:
   #!/usr/bin/env python3
   import subprocess
@@ -64,9 +65,6 @@ build *targets:
 
   # Rustc has a feature-gated option for multiple targets at once (-Zmultitarget) which may be worth looking into
 
-test:
-  @echo "test"
-
 # Print the system info for use in a bug report
 @info:
   echo "Please use the following data when preparing a bug report:"
@@ -83,3 +81,8 @@ clean-build *targets:
 doc:
   cargo doc
   @# When there is an mdbook it should compile that too
+
+# Add a script to release & publish latest version (with artifacts, tags etc)
+# Add a script that runs in CI
+# Add a script that runs all tests
+# Add a script that runs all benchmarks

--- a/justfile
+++ b/justfile
@@ -82,7 +82,15 @@ doc:
   cargo doc
   @# When there is an mdbook it should compile that too
 
+# This should probably be used when running CI
+# Output the health status of the codebase
+health:
+  cargo outdated
+  cargo deny check
+  cargo cache
+
 # Add a script to release & publish latest version (with artifacts, tags etc)
 # Add a script that runs in CI
 # Add a script that runs all tests
 # Add a script that runs all benchmarks
+# Add a script that lints all code

--- a/justfile
+++ b/justfile
@@ -93,6 +93,7 @@ health:
 install-toolchain:
   @if ! command -v rustup &> /dev/null; then \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh; \
+    source $HOME/.cargo/env \
   fi
   rustup update
 

--- a/justfile
+++ b/justfile
@@ -37,6 +37,8 @@ build *targets:
       'linux': 'x86_64-unknown-linux-gnu',
       'windows': 'x86_64-pc-windows-gnu',
       'mac': 'x86_64-apple-darwin',
+      'rpi': 'armv7-unknown-linux-gnueabihf',
+      'rpi-legacy': 'arm-unknown-linux-gnueabihf'
       # More shall be added soon...
   }
   SELECTED_TARGETS = '{{targets}}'.split(' ')

--- a/justfile
+++ b/justfile
@@ -69,4 +69,8 @@ test:
 
 # Print the system info for use in a bug report
 @info:
-  echo "{{arch()}} machine running on {{os()}}"
+  echo "Please use the following data when preparing a bug report:"
+  echo "Architecture: {{arch()}}"
+  echo "Operating system: {{os()}} ({{os_family()}})"
+  echo "Commit: {{`git rev-parse --short HEAD`}} ({{`git rev-parse HEAD`}})"
+  echo "Branch: {{`git rev-parse --abbrev-ref HEAD`}}"

--- a/justfile
+++ b/justfile
@@ -89,6 +89,17 @@ health:
   cargo deny check
   cargo cache
 
+# Install the KIROS development toolchain
+install-toolchain:
+  @if ! command -v rustup &> /dev/null; then \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh; \
+  fi
+  rustup update
+
+  cargo install cargo-outdated
+  cargo install cargo-deny
+  cargo install cargo-cache
+  
 # Add a script to release & publish latest version (with artifacts, tags etc)
 # Add a script that runs in CI
 # Add a script that runs all tests

--- a/justfile
+++ b/justfile
@@ -74,3 +74,12 @@ test:
   echo "Operating system: {{os()}} ({{os_family()}})"
   echo "Commit: {{`git rev-parse --short HEAD`}} ({{`git rev-parse HEAD`}})"
   echo "Branch: {{`git rev-parse --abbrev-ref HEAD`}}"
+
+clean-build *targets:
+  cargo clean
+  just build {{targets}}
+
+# Compile all project documentation
+doc:
+  cargo doc
+  @# When there is an mdbook it should compile that too

--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ build *targets:
           subprocess.run(['rustup', 'target', 'add', target], stderr=subprocess.DEVNULL, check=True)
 
           print(Colour.BOLD + Colour.BLUE + 'Compiling target' + Colour.END)
-          subprocess.run(['cargo', 'build', '--target', target], check=True)
+          subprocess.run(['cargo', 'build', '--target', target, '--release'], check=True)
 
   # Rustc has a feature-gated option for multiple targets at once (-Zmultitarget) which may be worth looking into
 
@@ -74,6 +74,8 @@ build *targets:
   echo "Operating system: {{os()}} ({{os_family()}})"
   echo "Commit: {{`git rev-parse --short HEAD`}} ({{`git rev-parse HEAD`}})"
   echo "Branch: {{`git rev-parse --abbrev-ref HEAD`}}"
+  echo "Cargo: {{`cargo version`}}"
+  echo "Rust: {{`rustc --version`}}"
 
 clean-build *targets:
   cargo clean
@@ -102,6 +104,11 @@ install-toolchain:
   cargo install cargo-outdated
   cargo install cargo-deny
   cargo install cargo-cache
+
+build-release:
+  just clean-build all
+  just doc
+# release: build-release
   
 # Add a script to release & publish latest version (with artifacts, tags etc)
 # Add a script that runs in CI

--- a/justfile
+++ b/justfile
@@ -1,8 +1,72 @@
+_default:
+  @just --choose
+
 # This script in particular will become very useful once we have more languages
 # supported
 # Lint the entire codebase
 lint:
-    cargo fmt
-    cargo fix --allow-dirty --allow-staged
+  cargo fmt
+  cargo fix --allow-dirty --allow-staged
 
-# There should be a recipe for getting system info too
+build *targets:
+  #!/usr/bin/env python3
+  import subprocess
+  import sys
+
+  class Colour:
+      PURPLE = '\033[95m'
+      CYAN = '\033[96m'
+      DARKCYAN = '\033[36m'
+      BLUE = '\033[94m'
+      GREEN = '\033[92m'
+      YELLOW = '\033[93m'
+      RED = '\033[91m'
+      BOLD = '\033[1m'
+      UNDERLINE = '\033[4m'
+      END = '\033[0m'
+
+
+  if '{{targets}}' == '':
+      print(Colour.BOLD + Colour.YELLOW + 'No target specified, building for local machine...'
+            + Colour.END)
+      subprocess.run(['cargo', 'build'], check=True)
+      sys.exit()
+
+  TARGETS = {
+      'linux': 'x86_64-unknown-linux-gnu',
+      'windows': 'x86_64-pc-windows-gnu',
+      'mac': 'x86_64-apple-darwin',
+      # More shall be added soon...
+  }
+  SELECTED_TARGETS = '{{targets}}'.split(' ')
+  TARGET_TRIPLES = []
+
+  if 'all' in SELECTED_TARGETS:
+      for target in TARGETS:
+          TARGET_TRIPLES.append(TARGETS[target])
+  else:
+      for target in SELECTED_TARGETS:
+          if target in TARGETS:
+              TARGET_TRIPLES.append(TARGETS[target])
+
+  if SELECTED_TARGETS == []:
+      print(Colour.BOLD + 'No valid TARGETS specified!' + Colour.END)
+  else:
+      print(Colour.BOLD + Colour.BLUE + 'Target(s):', Colour.CYAN
+            + ' '.join(TARGET_TRIPLES) + Colour.END)
+      for target in TARGET_TRIPLES:
+          print(Colour.BOLD + Colour.CYAN + target + Colour.END)
+          print(Colour.BOLD + Colour.BLUE + 'Installing target' + Colour.END)
+          subprocess.run(['rustup', 'target', 'add', target], stderr=subprocess.DEVNULL, check=True)
+
+          print(Colour.BOLD + Colour.BLUE + 'Compiling target' + Colour.END)
+          subprocess.run(['cargo', 'build', '--target', target], check=True)
+
+  # Rustc has a feature-gated option for multiple targets at once (-Zmultitarget) which may be worth looking into
+
+test:
+  @echo "test"
+
+# Print the system info for use in a bug report
+@info:
+  echo "{{arch()}} machine running on {{os()}}"

--- a/movement/Cargo.toml
+++ b/movement/Cargo.toml
@@ -3,6 +3,7 @@ name = "movement"
 version = "0.1.0"
 authors = ["Angus Finch <developer.finchie@gmail.com>"]
 edition = "2018"
+license = "MIT"
 
 [dependencies]
 sensor = { path = "../sensor" }

--- a/sensor/Cargo.toml
+++ b/sensor/Cargo.toml
@@ -3,6 +3,7 @@ name = "sensor"
 version = "0.1.0"
 authors = ["Angus Finch <developer.finchie@gmail.com>"]
 edition = "2018"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR adds various scripts designed to aid KIROS developers in creating & maintaining the repository. The following [just](https://github.com/casey/just) recipes have been added for this purpose:
- `build`
- `build-release`
- `clean-build`
- `doc`
- `health`
- `info`
- `install-toolchain`
- `lint`

In the future, this infrastructure should be able to be extended with minimal effort to support any variety of new targets.