### PR TITLE
Implement errors using anyhow

### DIFF
--- a/movement/Cargo.toml
+++ b/movement/Cargo.toml
@@ -12,6 +12,7 @@ num-traits = "0.2.14"
 phf = "0.8.0"
 ron = "0.6.4"
 serde = {version = "1.0.126", features = ["derive"]}
+thiserror = "1.0.25"
 
 [build-dependencies]
 phf_codegen = "0.8.0"

--- a/movement/build.rs
+++ b/movement/build.rs
@@ -54,6 +54,7 @@ fn main() {
     )
     .unwrap();
 
+    // These could be turned into a programmatically generated enum
     writeln!(
         &mut file,
         "static CONTROL_TABLE_TYPES: phf::Map<&'static str, ControlTableType> = \n{};\n",

--- a/movement/src/dynamixel/servo_connection.rs
+++ b/movement/src/dynamixel/servo_connection.rs
@@ -1,12 +1,18 @@
 use super::PacketManipulation;
 use std::io::{Read, Write};
 
+// NOTE: there isn't really any particular place to put this note so I'll just put it here
+// When connected to multiple Dynamixels running different protocols, it should be possible to differentiate
+// by doing one or both of these methods
+// - Pulling all bytes from buffer and treating it as a complete packet
+// - Attempt to parse as a protocol 2 packet before failing over to protocol 1
+
 pub fn write_packet<W, P>(connection: &mut W, packet: &P)
 where
     W: Write,
     P: PacketManipulation,
 {
-    let pck = packet.generate().unwrap();
+    let pck = packet.generate();
     connection.write(&pck).unwrap();
 }
 


### PR DESCRIPTION
The changes in this pull request standardise the error reporting across the `movement` crate. Moving forward, all `Result`s should use this format.